### PR TITLE
✨(CRUD) add admin route to delete allows

### DIFF
--- a/src/admin_routes/__init__.py
+++ b/src/admin_routes/__init__.py
@@ -33,6 +33,7 @@ def depends_api_db():
 
 DependsApiDb = typing.Annotated[orm.Session, fastapi.Depends(depends_api_db)]
 
+from .delete_allow import delete_allow
 from .get_allows import get_allows
 from .get_domains import get_domains
 from .get_user import get_user

--- a/src/admin_routes/delete_allow.py
+++ b/src/admin_routes/delete_allow.py
@@ -1,0 +1,28 @@
+import fastapi
+
+from src import auth, sql_api
+from src.admin_routes import DependsApiDb, allows
+
+
+@allows.delete("/{domain_name}/{user_name}", status_code=204)
+async def delete_allow(
+    db: DependsApiDb, user: auth.DependsBasicAdmin, domain_name: str, user_name: str
+) -> None:
+    """Remove user ownership of a domain."""
+
+    user_db = sql_api.get_api_user(db, user_name)
+    if user_db is None:
+        raise fastapi.HTTPException(status_code=404, detail="User not found")
+
+    domain_db = sql_api.get_api_domain(db, domain_name)
+    if domain_db is None:
+        raise fastapi.HTTPException(status_code=404, detail="Domain not found")
+
+    allowed_db = sql_api.get_api_allowed(db, user_name, domain_name)
+    if allowed_db is None:
+        raise fastapi.HTTPException(
+            status_code=404,
+            detail="Queried user does not have permissions for this domain.",
+        )
+
+    return sql_api.remove_domain_for_user(db, allowed_db)

--- a/src/admin_routes/post_allow.py
+++ b/src/admin_routes/post_allow.py
@@ -4,13 +4,16 @@ from .. import auth, sql_api, web_models
 from . import DependsApiDb, allows
 
 
-@allows.post("/")
+@allows.post("/", status_code=201)
 async def post_allow(
     db: DependsApiDb,
     user: auth.DependsBasicAdmin,
     allow: web_models.WAllowed,
 ) -> web_models.WAllowed:
+    """Give ownership of a domain to a user."""
+
     user_db = sql_api.get_api_user(db, allow.user)
+
     if user_db is None:
         raise fastapi.HTTPException(status_code=404, detail="User not found")
     domain_db = sql_api.get_api_domain(db, allow.domain)

--- a/src/admin_routes/post_domain.py
+++ b/src/admin_routes/post_domain.py
@@ -4,7 +4,7 @@ from .. import auth, oxcli, sql_api, web_models
 from . import DependsApiDb, domains
 
 
-@domains.post("/")
+@domains.post("/", status_code=201)
 async def post_domain(
     db: DependsApiDb,
     user: auth.DependsBasicAdmin,

--- a/src/admin_routes/post_user.py
+++ b/src/admin_routes/post_user.py
@@ -4,12 +4,14 @@ from .. import auth, sql_api, web_models
 from . import DependsApiDb, users
 
 
-@users.post("/")
+@users.post("/", status_code=201)
 async def post_user(
     db: DependsApiDb,
     admin: auth.DependsBasicAdmin,
     user: web_models.CreateUser,
 ) -> web_models.WUser:
+    """Create user."""
+
     user_db = sql_api.get_api_user(db, user.name)
 
     if user_db is not None:

--- a/src/admin_routes/test_basic.py
+++ b/src/admin_routes/test_basic.py
@@ -1,11 +1,11 @@
 import fastapi.testclient
 
-from .. import main
+from src import main, sql_api, web_models
 
 client = fastapi.testclient.TestClient(main.app)
 
 
-def test_something(db_api, ox_cluster, log):
+def test_users__create(db_api, ox_cluster, log):
     # At the beginning of time, databse is empty, random users accepted and are admins
     response = client.get("/admin/users", auth=("useless", "useless"))
     assert response.status_code == 200
@@ -15,7 +15,7 @@ def test_something(db_api, ox_cluster, log):
         json={"name": "first_admin", "password": "toto", "is_admin": True},
         auth=("useless", "useless"),
     )
-    assert response.status_code == 200
+    assert response.status_code == fastapi.status.HTTP_201_CREATED
     # TODO : Comment piloter la génération des uuid depuis les tests pour les rendre prédictibles ?
     uuid = response.json()["uuid"]
     assert response.json() == {"name": "first_admin", "uuid": uuid, "is_admin": True}
@@ -49,3 +49,82 @@ def test_something(db_api, ox_cluster, log):
     )
     assert response.status_code == 409
     assert response.json() == {"detail": "User already exists"}
+
+
+def test_domains__fails_no_name(db_api_session, log):
+    """Cannot create domain with no name."""
+
+    response = client.post(
+        "/admin/domains",
+        json={
+            "context_name": "context",
+            "name": None,
+            "features": ["mailbox", "webmail", "alias"],
+        },
+        auth=("useless", "useless"),
+    )
+    assert response.status_code == fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.json() == {
+        "detail": [
+            {
+                "type": "string_type",
+                "loc": ["body", "name"],
+                "msg": "Input should be a valid string",
+                "input": None,
+            }
+        ]
+    }
+
+
+def test_domains__create_domain_successful(db_api_session, log):
+    """Succesfully create domain."""
+
+    response = client.post(
+        "/admin/domains",
+        json={
+            "context_name": "context",
+            "name": "domain",
+            "features": ["mailbox", "webmail", "alias"],
+        },
+        auth=("", ""),
+    )
+    assert response.status_code == fastapi.status.HTTP_201_CREATED
+    assert response.json() == {
+        "name": "domain",
+        "features": ["mailbox", "webmail", "alias"],
+        "mailbox_domain": None,
+        "webmail_domain": None,
+        "imap_domains": None,
+        "smtp_domains": None,
+        "context_name": "context",
+    }
+
+
+def test_allows__create_allows(db_api_session, log):
+    """Create "allows" object, granting an user management permissions to a domain."""
+
+    # Create first admin for later auth
+    auth = ("admin", "admin_password")
+    sql_api.create_api_user(
+        db_api_session, name=auth[0], password=auth[1], is_admin=True
+    )
+
+    # Create user and domain before access
+    user = sql_api.create_api_user(
+        db_api_session, name="user", password="password", is_admin=False
+    )
+    domain = sql_api.create_api_domain(
+        db_api_session,
+        domain=web_models.WDomain(context_name="context", name="domain", features=[]),
+    )
+
+    # Create allows for this user on this domain
+    response = client.post(
+        "/admin/allows/", json={"domain": domain.name, "user": user.name}, auth=auth
+    )
+
+    assert response.status_code == fastapi.status.HTTP_201_CREATED
+    assert response.json() == {"user": user.name, "domain": domain.name}
+
+    # GET list of "allows" should return 1 result
+    assert len(client.get("/admin/allows/", auth=auth).json()) == 1

--- a/src/auth/basic_user.py
+++ b/src/auth/basic_user.py
@@ -10,7 +10,7 @@ from . import err
 
 
 def authenticate_user(db: orm.Session, user_name: str, password: str) -> sql_api.DBUser:
-    """Fetch a user from the API db, checks his password, if everything
+    """Fetch a user from the API db, checks their password, if everything
     is fine, returns the user. Will raise a PermissionDenied exception
     if something is wrong.
     May forge an admin user if the API db is empty."""

--- a/src/auth/token_user.py
+++ b/src/auth/token_user.py
@@ -46,8 +46,8 @@ class TokenUser(fastapi.security.HTTPBearer):
             session.close()
             raise
         log.info(f"Got the user in db: {user}")
-        # We need to keep the orm session running, to that the user object is
-        # usable (he needs his orm session for some operations)
+        # We need to keep the orm session running, so that the user object is
+        # usable (it needs its orm session for some operations)
         try:
             yield user
         finally:

--- a/src/routes/get_mailbox.py
+++ b/src/routes/get_mailbox.py
@@ -14,7 +14,7 @@ uuid_re = re.compile("^[0-9a-f-]{32,36}$")
 @mailboxes.get(
     "/{mailbox_id}",
     responses={
-        200: {"description": "Get a mailbox from his e_mail"},
+        200: {"description": "Get a mailbox from their e-mail"},
         403: {"description": "Permission denied"},
         404: {"description": "Mailbox not found"},
         422: {"description": "Email address is not well formed"},

--- a/src/routes/post_mailbox.py
+++ b/src/routes/post_mailbox.py
@@ -11,10 +11,7 @@ from . import DependsDovecotDb, mailboxes
 mail_re = re.compile("^(?P<username>[^@]+)@(?P<domain>[^@]+)$")
 
 
-@mailboxes.post(
-    "/",
-    description="Create a mailbox in dovecot and OX",
-)
+@mailboxes.post("/", description="Create a mailbox in dovecot and OX", status_code=201)
 async def post_mailbox(
     mailbox: web_models.CreateMailbox,
     user: auth.DependsTokenUser,
@@ -42,7 +39,7 @@ async def post_mailbox(
         log.error(f"Le domaine {domain} est inconnu du cluster OX")
         raise Exception("Le domaine est connu de la base API, mais pas de OX")
 
-    ox_user = ctx.create_user(
+    ctx.create_user(
         givenName=mailbox.givenName,
         surName=mailbox.surName,
         username=username,
@@ -57,5 +54,3 @@ async def post_mailbox(
         password=password,
         uuid=uuid.uuid4(),
     )
-
-

--- a/src/routes/test_basic.py
+++ b/src/routes/test_basic.py
@@ -17,7 +17,7 @@ def my_user(ox_cluster, db_api, log):
         json={"name": "admin", "password": "admin", "is_admin": True},
         auth=("useless", "useless"),
     )
-    assert res.status_code == 200
+    assert res.status_code == fastapi.status.HTTP_201_CREATED
 
     # Now, we can create our non-admin user
     res = client.post(
@@ -25,7 +25,7 @@ def my_user(ox_cluster, db_api, log):
         json={"name": user, "password": "toto", "is_admin": False},
         auth=("admin", "admin"),
     )
-    assert res.status_code == 200
+    assert res.status_code == fastapi.status.HTTP_201_CREATED
 
     res = client.post(
         "/admin/domains/",
@@ -36,7 +36,7 @@ def my_user(ox_cluster, db_api, log):
         },
         auth=("admin", "admin"),
     )
-    assert res.status_code == 200
+    assert res.status_code == fastapi.status.HTTP_201_CREATED
 
     ctx = ox_cluster.get_context_by_name("dimail")
     assert domain in ctx.domains
@@ -46,7 +46,7 @@ def my_user(ox_cluster, db_api, log):
         json={"user": user, "domain": domain},
         auth=("admin", "admin"),
     )
-    assert res.status_code == 200
+    assert res.status_code == fastapi.status.HTTP_201_CREATED
 
     res = client.get("/token/", auth=(user, "toto"))
     assert res.status_code == 200
@@ -68,7 +68,7 @@ def test_create_mailbox(ox_cluster, my_user, db_dovecot_session):
         },
         headers={"Authorization": f"Bearer {token}"},
     )
-    assert response.status_code == 200
+    assert response.status_code == fastapi.status.HTTP_201_CREATED
     # FIXME On a besoin de rendre prédictible les uuid qu'on génère pendant
     # les tests. On a aussi besoin de définir ce que c'est que l'uuid d'une
     # mailbox, parce que ce n'est pas clair pour l'instant...

--- a/src/sql_api/__init__.py
+++ b/src/sql_api/__init__.py
@@ -11,6 +11,7 @@ from .crud import (
     get_api_user,
     get_api_users,
     nb_users,
+    remove_domain_for_user,
 )
 from .database import get_api_db, get_maker, init_api_db
 from .models import DBAllowed, DBDomain, DBUser

--- a/src/sql_api/crud.py
+++ b/src/sql_api/crud.py
@@ -91,3 +91,15 @@ def allow_domain_for_user(db: orm.Session, allowed: web_models.WAllowed):
     db.commit()
     db.refresh(db_allowed)
     return db_allowed
+
+
+def remove_domain_for_user(db: orm.Session, allowed: web_models.WAllowed):
+    """Remove domain ownership to user. The user won't be able to add/delete mailboxes for this domain."""
+    db_allowed = (
+        db.query(models.DBAllowed)
+        .filter_by(domain=allowed.domain, user=allowed.user)
+        .first()
+    )
+    db.delete(db_allowed)
+    db.commit()
+    return {}


### PR DESCRIPTION
# 🔍️ Goal
J'ajoute une admin_route pour supprimer les "allows". 
J'en profite pour me familiariser avec nos tests et en ajouter 2, pour la création et la suppression des "allows".

# 🔨 Implémentation
- Ajout d'un uuid sur les "allows" pour pouvoir ensuite appeler DELETE sur `/allows/<alllow_uuid>`. Alternativement, on pourrait imbriquer "allows" sous domaine par exemple pour appeler DELETE sur `domains/<domain_identifier>/allows/<user_identifier>.` Je veux bien votre avis là-dessus.
- Utilisation de "sql_api" dans les tests unitaires pour tout ce qui ne concerne pas l'objet du test (i.e.: créer le premier admin, créer un user et un domaine avant de créer un "allows", etc)
- ajout de quelques tests autour du domaine et des allows

# 💡 Suggestions 
- renommer les "allows" en un nom, comme "owns" ou quelque chose dans ce goût. A discuter avec l'équipe pour qu'on se mette d'accord sur un truc qui fait sens par rapport à Desk.