### PR TITLE
Feat/add testcontainers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+
+  - package-ecosystem: docker
+    directory: /oxtest
+    schedule:
+      interval: daily

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -1,3 +1,4 @@
 api_db_url  = "mysql+pymysql://api_user:invalide@localhost:3306/api"
 imap_db_url = "mysql+pymysql://dovecot:invalide@localhost:3306/dovecot"
 postfix_db_url = "mysql+pymysql://postfix:invalide@localhost:3306/postfix"
+ox_ssh_url = "ssh://root@localhost:2222"

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -2,3 +2,4 @@ api_db_url  = "mysql+pymysql://api_user:invalide@localhost:3306/api"
 imap_db_url = "mysql+pymysql://dovecot:invalide@localhost:3306/dovecot"
 postfix_db_url = "mysql+pymysql://postfix:invalide@localhost:3306/postfix"
 ox_ssh_url = "ssh://root@localhost:2222"
+ox_ssh_args = []

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -3,3 +3,4 @@ imap_db_url = "mysql+pymysql://dovecot:invalide@localhost:3306/dovecot"
 postfix_db_url = "mysql+pymysql://postfix:invalide@localhost:3306/postfix"
 ox_ssh_url = "ssh://root@localhost:2222"
 ox_ssh_args = []
+test_containers = "True"

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -3,4 +3,4 @@ imap_db_url = "mysql+pymysql://dovecot:invalide@localhost:3306/dovecot"
 postfix_db_url = "mysql+pymysql://postfix:invalide@localhost:3306/postfix"
 ox_ssh_url = "ssh://root@localhost:2222"
 ox_ssh_args = []
-test_containers = "True"
+test_containers = false

--- a/oxtest/Dockerfile
+++ b/oxtest/Dockerfile
@@ -15,13 +15,13 @@ RUN apt-get install -y temurin-8-jdk open-xchange open-xchange-admin open-xchang
 RUN apt-get install -y openssh-server openssh-client
 
 WORKDIR /etc/ssh
-COPY --chmod=400 ./ssh_host_ecdsa_key ./ssh_host_ecdsa_key.pub .
-COPY --chmod=400 ./ssh_host_ed25519_key ./ssh_host_ed25519_key.pub .
-COPY --chmod=400 ./ssh_host_rsa_key ./ssh_host_rsa_key.pub
+COPY --chmod=400 ./ssh_host_ecdsa_key ./ssh_host_ecdsa_key.pub ./
+COPY --chmod=400 ./ssh_host_ed25519_key ./ssh_host_ed25519_key.pub ./
+COPY --chmod=400 ./ssh_host_rsa_key ./ssh_host_rsa_key.pub ./
 
 WORKDIR /root
 COPY ./authorized_keys ./.ssh/authorized_keys
-COPY --chmod=0755 ./setup.sh ./purge.sh .
+COPY --chmod=0755 ./setup.sh ./purge.sh ./
 
 RUN mkdir /run/sshd
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,6 @@ passlib==1.7.4
 argon2-cffi==23.1.0
 python-multipart==0.0.9
 PyJWT==2.8.0
-testcontainers[mysql]==4.4.0
+testcontainers[mysql]==4.5.0
 docker==7.1.0 # https://github.com/docker/docker-py/issues/3256
+python-on-whales==0.71.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ passlib==1.7.4
 argon2-cffi==23.1.0
 python-multipart==0.0.9
 PyJWT==2.8.0
+testcontainers[mysql]==4.4.0
+docker==7.1.0 # https://github.com/docker/docker-py/issues/3256

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -295,7 +295,6 @@ def mariadb_container(log, request, dimail_test_network) -> tc.MySqlContainer | 
 
     mysql = (tc.MySqlContainer("mariadb:11.2", username="root", password="toto", dbname="mysql")
              # .with_name("mariadb")
-             .with_bind_ports(3306, 3306)
              .with_network(dimail_test_network)
              .with_network_aliases("mariadb"))
     log.info("SETUP MARIADB CONTAINER")

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -276,6 +276,8 @@ def ox_container(log, request, dimail_test_network, mariadb_container, ox_contai
     ox_ssh_url = f"ssh://root@{ox.get_container_host_ip()}:{ox.get_exposed_port(22)}"
     log.info(f"url de connexion ssh vers le cluster OX -> {ox_ssh_url}")
     config.settings.ox_ssh_url = ox_ssh_url
+    # on ne veut pas vérifier la clé sur chaque port randon du conteneur
+    config.settings.ox_ssh_args = ["-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null"]
 
     def remove_container():
         log.info("TEARDOWN OX CONTAINER")
@@ -329,9 +331,10 @@ def ox_container_image(log, request) -> str | None:
 def dimail_test_network(log) -> typing.Generator:
     if not need_start_test_container():
         yield None
-    with Network() as dimail_test_network:
-        log.info(f"crée un réseau Docker -> {dimail_test_network}")
-        yield dimail_test_network
+    else:
+        with Network() as dimail_test_network:
+            log.info(f"crée un réseau Docker -> {dimail_test_network}")
+            yield dimail_test_network
 
 
 def need_start_test_container() -> bool:

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -13,7 +13,7 @@ from testcontainers.core.container import DockerContainer
 from testcontainers.core.network import Network
 from testcontainers.core.waiting_utils import wait_for_logs
 
-from . import oxcli, sql_api, sql_dovecot, sql_postfix
+from . import oxcli, sql_api, sql_dovecot, sql_postfix, config
 
 
 def make_db(name: str, conn: sa.Connection) -> str:
@@ -249,12 +249,8 @@ def db_postfix_session(db_postfix, log) -> typing.Generator:
 @pytest.fixture(scope="function")
 def ox_cluster(log, ox_container) -> typing.Generator:
     """Fixture that provides an empty OX cluster."""
-    # ox_ssh_url  = f"ssh://root@{ox_container.get_container_host_ip()}:{ox_container.get_exposed_port(22)}"
     log.info(f"SETUP empty ox cluster")
     ox_cluster = oxcli.OxCluster()
-    if ox_container:
-        ox_ssh_url = f"ssh://root@{ox_container.get_container_host_ip()}:{ox_container.get_exposed_port(22)}"
-        ox_cluster.ssh_url = ox_ssh_url
     log.info(f"url de connexion ssh vers le cluster OX -> {ox_cluster.url()}")
     ox_cluster.purge()
     yield ox_cluster
@@ -277,8 +273,9 @@ def ox_container(log, request, dimail_test_network, mariadb_container, ox_contai
     log.info(f"ox started in -> {delay}s")
     time.sleep(1)  # pour être sûr que le service ssh est up
 
-    # ox_ssh_url = f"ssh://root@{ox.get_container_host_ip()}:{ox.get_exposed_port(22)}"
-    # log.info(f"url de connexion ssh vers le cluster OX -> {ox_ssh_url}")
+    ox_ssh_url = f"ssh://root@{ox.get_container_host_ip()}:{ox.get_exposed_port(22)}"
+    log.info(f"url de connexion ssh vers le cluster OX -> {ox_ssh_url}")
+    config.settings.ox_ssh_url = ox_ssh_url
 
     def remove_container():
         log.info("TEARDOWN OX CONTAINER")

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -281,11 +281,7 @@ def ox_name(log, dimail_test_network, root_db_url) -> typing.Generator:
     one in docker compose, according to the setting of
     `DIMAIL_TEST_CONTAINERS`."""
     if not config.settings.test_containers:
-        oxcli.declare_cluster(
-            "default",
-            config.settings.ssh_url,
-            config.settings.ssh_args,
-        )
+        # We use the OX cluster declared in main.py
         yield "default"
         # We don't want to build a container as the teardown of the fixture.
         return

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -29,7 +29,8 @@ def make_db_with_user(name: str, user: str, password: str, conn: sa.Connection) 
     conn.execute(sa.text(f"create database {name};"))
     conn.execute(sa.text(f"grant ALL on {name}.* to {user}@'%' identified by '{password}';"))
     mariadb_port = conn.engine.url.port
-    return f"mysql+pymysql://{user}:{password}@localhost:{mariadb_port}/{name}"
+    mariadb_host = conn.engine.url.host
+    return f"mysql+pymysql://{user}:{password}@{mariadb_host}:{mariadb_port}/{name}"
 
 
 def drop_db(name: str, conn: sa.Engine):
@@ -73,6 +74,7 @@ def engine(mysql_container):
 def root_db(log, mariadb_container) -> typing.Generator:
     """Fixtures that makes a connection to mariadb/mysql as root available."""
     log.info("CONNECTING as mysql root")
+    # root_db = sa.create_engine("mysql+pymysql://root:toto@localhost:3306/mysql")
     root_db = sa.create_engine(mariadb_container.get_connection_url())
     conn = root_db.connect()
     yield conn

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -10,10 +10,9 @@ import sqlalchemy as sa
 import alembic.command
 import alembic.config
 
-from . import oxcli, sql_api, sql_dovecot, sql_postfix
-from testcontainers.mysql import MySqlContainer
+import testcontainers.mysql as tc
 
-from . import oxcli, sql_api, sql_dovecot
+from . import oxcli, sql_api, sql_dovecot, sql_postfix
 
 
 def make_db(name: str, conn: sa.Connection) -> str:
@@ -56,7 +55,7 @@ def mariadb_container(log, request):
     """
     if not os.environ.get("DIMAIL_STARTS_TESTS_CONTAINERS"):
         return None
-    mysql = MySqlContainer("mariadb:11.2", username="root", password="password_root", dbname="mysql")
+    mysql = tc.MySqlContainer("mariadb:11.2", username="root", password="password_root", dbname="mysql")
     log.info("SETUP MARIADB CONTAINER")
     mysql.start()
 

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -276,7 +276,7 @@ def ox_container(log, request, dimail_test_network, mariadb_container, ox_contai
         log.info(f"ox started in -> {delay}s")
         time.sleep(1)  # pour être sûr que le service ssh est up
     except Exception as e:
-        log.info(f"Le conteneur {ox_container_image} n'a pas pu démarrer {e}")
+        log.info(f"Le conteneur {ox_container_image} n'a pas démarré {e}")
         pytest.skip()
     log.info(f"url de ox_container -> {ox.get_container_host_ip()}:{ox.get_exposed_port(22)}")
 
@@ -306,7 +306,7 @@ def mariadb_container(log, request, dimail_test_network) -> tc.MySqlContainer | 
     try:
         mysql.start()
         delay = wait_for_logs(mysql, "MariaDB init process done. Ready for start up.")
-        log.info(f"MARIADB starts in {delay}s")
+        log.info(f"MARIADB started in {delay}s")
     except Exception as e:
         log.info(f"Le conteneur {mysql} n'a pas démarré {e}")
         pytest.skip()

--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,17 @@
 import fastapi
 
-from . import admin_routes, config, routes, sql_api, sql_dovecot, sql_postfix
+from . import admin_routes, config, oxcli, routes, sql_api, sql_dovecot, sql_postfix
 
 sql_api.init_db(config.settings.api_db_url)
 sql_dovecot.init_db(config.settings.imap_db_url)
 sql_postfix.init_db(config.settings.postfix_db_url)
+
+oxcli.declare_cluster(
+    "default",
+    config.settings.ox_ssh_url,
+    []
+)
+oxcli.set_default_cluster("default")
 
 if config.settings.JWT_SECRET == "bare secret":
     raise Exception("please configure JWT_SECRET")

--- a/src/oxcli/__init__.py
+++ b/src/oxcli/__init__.py
@@ -1,1 +1,2 @@
 from .ox import OxCluster, OxContext, OxUser
+from .setup import declare_cluster, get_cluster_info, set_default_cluster

--- a/src/oxcli/ox.py
+++ b/src/oxcli/ox.py
@@ -14,6 +14,7 @@ class OxCluster(pydantic.BaseModel):
     admin_username: str = "admin_user"
     admin_password: str = "admin_pass"
     ssh_url: str | None = None
+    ssh_args: list[str] = []
 
     def url(self):
         return self.ssh_url
@@ -21,6 +22,7 @@ class OxCluster(pydantic.BaseModel):
     def __init__(self):
         super().__init__()
         self.ssh_url = config.settings.ox_ssh_url
+        self.ssh_args = config.settings.ox_ssh_args
 
 
 class OxContext(pydantic.BaseModel):
@@ -95,7 +97,7 @@ def __cmd(args: list[str]) -> str:
 
 def _run_for_csv(self: OxCluster, command: list[str]) -> list[str]:
     file = subprocess.Popen(
-        ["ssh", self.ssh_url, __cmd(command)],
+        ["ssh"] + self.ssh_args + [self.ssh_url, __cmd(command)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
@@ -117,7 +119,7 @@ def _run_for_csv(self: OxCluster, command: list[str]) -> list[str]:
 
 def _run_for_item(self: OxCluster, command: list[str]) -> str:
     file = subprocess.Popen(
-        ["ssh", self.ssh_url, __cmd(command)],
+        ["ssh"] + self.ssh_args + [self.ssh_url, __cmd(command)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,

--- a/src/oxcli/ox.py
+++ b/src/oxcli/ox.py
@@ -5,13 +5,22 @@ import subprocess
 
 import pydantic
 
+from src import config
+
 
 class OxCluster(pydantic.BaseModel):
     master_username: str = "master_user"
     master_password: str = "master_pass"
     admin_username: str = "admin_user"
     admin_password: str = "admin_pass"
-    ssh_url: str = "ssh://root@localhost:2222"
+    ssh_url: str = config.settings.ox_ssh_url
+
+    def url(self):
+        return self.ssh_url
+
+    # @classmethod
+    # def with_ssh_url(cls, ssh_url: str):
+    #     return cls(ssh_url=ssh_url)
 
 
 class OxContext(pydantic.BaseModel):
@@ -168,7 +177,7 @@ def _get_context_by_domain(self: OxCluster, domain: str) -> OxContext | None:
 
 
 def _create_context(
-    self: OxCluster, cid: int | None, name: str, domain: str
+        self: OxCluster, cid: int | None, name: str, domain: str
 ) -> OxContext:
     all_contexts = self.list_contexts()
     max_id = 0
@@ -301,13 +310,13 @@ def _displayname_exists(self: OxContext, display_name: str) -> bool:
 
 
 def _create_user(
-    self: OxContext,
-    surName: str,
-    givenName: str,
-    displayName: str | None = None,
-    email: str | None = None,
-    username: str | None = None,
-    domain: str | None = None,
+        self: OxContext,
+        surName: str,
+        givenName: str,
+        displayName: str | None = None,
+        email: str | None = None,
+        username: str | None = None,
+        domain: str | None = None,
 ) -> OxUser:
     if email is None and username is not None and domain is not None:
         email = username + "@" + domain

--- a/src/oxcli/ox.py
+++ b/src/oxcli/ox.py
@@ -13,14 +13,14 @@ class OxCluster(pydantic.BaseModel):
     master_password: str = "master_pass"
     admin_username: str = "admin_user"
     admin_password: str = "admin_pass"
-    ssh_url: str = config.settings.ox_ssh_url
+    ssh_url: str | None = None
 
     def url(self):
         return self.ssh_url
 
-    # @classmethod
-    # def with_ssh_url(cls, ssh_url: str):
-    #     return cls(ssh_url=ssh_url)
+    def __init__(self):
+        super().__init__()
+        self.ssh_url = config.settings.ox_ssh_url
 
 
 class OxContext(pydantic.BaseModel):

--- a/src/oxcli/setup.py
+++ b/src/oxcli/setup.py
@@ -1,0 +1,34 @@
+
+default_cluster = None
+clusters = {}
+
+def declare_cluster(
+    name: str,
+    ssh_url: str,
+    ssh_args: list[str] = [],
+):
+    global clusters
+    if name in clusters:
+        raise Exception(f"Cluster {name} already declared")
+
+    clusters[name] = {
+        "url": ssh_url,
+        "args": ssh_args,
+    }
+
+def set_default_cluster(name: str):
+    global default_cluster
+    if name not in clusters:
+        raise Exception(f"Cluster {name} does not exist, it cannot be the default one")
+
+    default_cluster = name
+
+def get_cluster_info(name: str | None = None):
+    if name is None:
+        name = default_cluster
+
+    if name not in clusters:
+        raise Exception(f"The cluster {name} does not exist")
+
+    return (name, clusters[name]["url"], clusters[name]["args"])
+

--- a/src/sql_api/test_container.py
+++ b/src/sql_api/test_container.py
@@ -1,9 +1,0 @@
-import sqlalchemy as sa
-
-
-def test_mysql_version(mysql_container, log):
-    engine = sa.create_engine(mysql_container.get_connection_url())
-    with engine.begin() as connection:
-        result = connection.execute(sa.text("select version()"))
-        version, = result.fetchone()
-    assert version.startswith("5.7.17")

--- a/src/sql_api/test_container.py
+++ b/src/sql_api/test_container.py
@@ -1,0 +1,9 @@
+import sqlalchemy as sa
+
+
+def test_mysql_version(mysql_container, log):
+    engine = sa.create_engine(mysql_container.get_connection_url())
+    with engine.begin() as connection:
+        result = connection.execute(sa.text("select version()"))
+        version, = result.fetchone()
+    assert version.startswith("5.7.17")

--- a/src/utils/test_basic.py
+++ b/src/utils/test_basic.py
@@ -2,8 +2,8 @@ import pytest
 
 from .. import utils
 
-def test_split_email():
 
+def test_split_email():
     (username, domain) = utils.split_email("test@example.com")
     assert username == "test"
     assert domain == "example.com"
@@ -11,7 +11,3 @@ def test_split_email():
     with pytest.raises(Exception) as e:
         (username, domain) = utils.split_email("not-an-email")
     assert str(e) == "<ExceptionInfo Exception('The email address <not-an-email> is not valid') tblen=2>"
-
-
-
-


### PR DESCRIPTION
ajoute un mécanisme de lancement de container pour les tests utnitaires avec python :
- ça permet de lancer des containers sur des ports random 
- ça permet ensuite de lancer un pipeline de ci avec github

_cela a nécessité une modification de la déclaration des OxClusters