### PR TITLE
✨(api) add domain details endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,11 @@
-[tool.ruff.lint]
-ignore = []
+[tool.ruff]
+line-length = 100
 
+[tool.ruff.lint]
+select = [
+    # Pyflakes
+    "F",
+    # Pycodestyle
+    "E",
+    "W",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[flake8]
-exclude = .git, venv, */__init__.py, src/alembic/versions/*
-extend-ignore = E203, E501
-# Whitespace before ':' (E203) : https://www.flake8rules.com/rules/E203.html
-# Line too long (82 &gt; 79 characters) (E501) : https://www.flake8rules.com/rules/E2501.html

--- a/src/admin_routes/get_domains.py
+++ b/src/admin_routes/get_domains.py
@@ -8,4 +8,4 @@ async def get_domains(
     user: auth.DependsBasicAdmin,
 ) -> list[web_models.Domain]:
     domains = sql_api.get_domains(db)
-    return [web_models.Domain.from_db(dom) for dom in domains]
+    return [web_models.Domain.from_db(domain) for domain in domains]

--- a/src/admin_routes/test_basic.py
+++ b/src/admin_routes/test_basic.py
@@ -76,7 +76,7 @@ def test_domains__fails_no_name(db_api_session, log):
     }
 
 
-def test_domains__create_domain_successful(db_api_session, log):
+def test_domains__create_successful(db_api_session, log):
     """Succesfully create domain."""
 
     response = client.post(
@@ -108,9 +108,7 @@ def test_allows__create_allows(db_api_session, log):
     sql_api.create_user(db_api_session, name=auth[0], password=auth[1], is_admin=True)
 
     # Create user and domain before access
-    user = sql_api.create_user(
-        db_api_session, name="user", password="password", is_admin=False
-    )
+    user = sql_api.create_user(db_api_session, name="user", password="password", is_admin=False)
     domain = sql_api.create_domain(
         db_api_session,
         name="domain",
@@ -137,9 +135,7 @@ def test_allows__delete_allows(db_api_session, log):
     sql_api.create_user(db_api_session, name=auth[0], password=auth[1], is_admin=True)
 
     # Create allows and related user and domain
-    user = sql_api.create_user(
-        db_api_session, name="user", password="password", is_admin=False
-    )
+    user = sql_api.create_user(db_api_session, name="user", password="password", is_admin=False)
     domain = sql_api.create_domain(
         db_api_session,
         name="domain",

--- a/src/main.py
+++ b/src/main.py
@@ -23,6 +23,7 @@ app.include_router(admin_routes.users)
 app.include_router(admin_routes.domains)
 app.include_router(admin_routes.allows)
 
+app.include_router(routes.domains)
 app.include_router(routes.token)
 app.include_router(routes.mailboxes)
 app.include_router(routes.aliases)

--- a/src/routes/__init__.py
+++ b/src/routes/__init__.py
@@ -1,11 +1,16 @@
 # ruff: noqa: E402
-
 import typing
 
 import fastapi.security
 import sqlalchemy.orm as orm
 
 from .. import sql_api, sql_dovecot, sql_postfix
+
+
+domains = fastapi.APIRouter(
+    prefix="/domains",
+    tags=["domains"],
+)
 
 mailboxes = fastapi.APIRouter(prefix="/mailboxes", tags=["mailboxes"])
 aliases = fastapi.APIRouter(prefix="/aliases", tags=["aliases"])
@@ -62,15 +67,17 @@ DependsPostfixDb = typing.Annotated[typing.Any, fastapi.Depends(depends_postfix_
 from .get_alias import get_alias
 from .get_mailbox import get_mailbox
 from .get_mailboxes import get_mailboxes
+from .get_domain import get_domain
 from .get_token import login_for_access_token
 from .post_alias import post_alias
 from .post_mailbox import post_mailbox
 
 __all__ = [
-    get_alias,
-    get_mailbox,
     get_mailboxes,
     login_for_access_token,
     post_alias,
     post_mailbox,
+    get_domain,
+    get_alias,
+    get_mailbox,
 ]

--- a/src/routes/get_domain.py
+++ b/src/routes/get_domain.py
@@ -1,0 +1,25 @@
+import fastapi
+from .. import auth, sql_api, web_models
+from . import DependsApiDb, domains
+import logging
+
+
+@domains.get("/{domain_name}")
+async def get_domain(
+    db: DependsApiDb,
+    user: auth.DependsTokenUser,
+    domain_name: str,
+) -> web_models.Domain:
+    log = logging.getLogger(__name__)
+    perms = user.get_creds()
+
+    domain_db = sql_api.get_domain(db, domain_name)
+    if domain_db is None:
+        log.info(f"Domain {domain_name} not found.")
+        raise fastapi.HTTPException(status_code=404, detail="Domain not found")
+
+    if not perms.can_read(domain_name):
+        log.info(f"Permission denied on domain {domain_name} for user.")
+        raise fastapi.HTTPException(status_code=401, detail="Not authorized.")
+
+    return web_models.Domain.from_db(domain_db)


### PR DESCRIPTION
# 🎯 Goal

Accéder aux détails d'un domaine quand on a un "allow" sur ce domaine. 
L'idée derrière c'est de lister/créer des mailboxes sur ce domaine. 

# 🔨 Implémentation

J'ai créé la route dans "routes/" et pas "admin_routes/", pour que `domains/mon-domain.fr/mailboxes/" soit accessible. C'est aussi ce qu'on s'était dit dans une conversation informelle avec @chrnin (et qu'il faudrait qu'on formalise pour être raccord sur la direction)